### PR TITLE
Support copying relative path from binary/non-text tabs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,19 +24,69 @@ export function activate(context: vscode.ExtensionContext) {
   // Always show so it's available even when focus is in the sidebar
   statusBarItem.show();
 
+  const getActiveUri = (): vscode.Uri | undefined => {
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+      return editor.document.uri;
+    }
+
+    const activeTab = vscode.window.tabGroups.activeTabGroup?.activeTab;
+    if (!activeTab) {
+      return undefined;
+    }
+
+    const input = activeTab.input as
+      | vscode.TabInputText
+      | vscode.TabInputTextDiff
+      | vscode.TabInputCustom
+      | vscode.TabInputNotebook
+      | vscode.TabInputWebview
+      | { uri?: vscode.Uri }
+      | { modified?: vscode.Uri; original?: vscode.Uri };
+
+    if (input instanceof vscode.TabInputText) {
+      return input.uri;
+    }
+
+    if (input instanceof vscode.TabInputTextDiff) {
+      return input.modified ?? input.original;
+    }
+
+    if (input instanceof vscode.TabInputCustom) {
+      return input.uri;
+    }
+
+    if (input instanceof vscode.TabInputNotebook) {
+      return input.uri;
+    }
+
+    if ("uri" in input && input.uri instanceof vscode.Uri) {
+      return input.uri;
+    }
+
+    if ("modified" in input && input.modified instanceof vscode.Uri) {
+      return input.modified;
+    }
+
+    if ("original" in input && input.original instanceof vscode.Uri) {
+      return input.original;
+    }
+
+    return undefined;
+  };
+
   // Command: Copy relative path only (no line/column)
   // Triggered by: editor title button click, Cmd+Alt+C (macOS) / Ctrl+Alt+C (Win/Linux)
   const copyDisposable = vscode.commands.registerCommand(
     "copy-relative-path-button.copyRelativePath",
     async () => {
-      const editor = vscode.window.activeTextEditor;
-      if (!editor) {
+      const uri = getActiveUri();
+      if (!uri) {
         vscode.window.showErrorMessage("No active editor");
         return;
       }
 
       // Get the file path relative to the workspace root
-      const uri = editor.document.uri;
       const path = vscode.workspace.asRelativePath(uri);
 
       // Copy to clipboard and show feedback
@@ -69,7 +119,9 @@ export function activate(context: vscode.ExtensionContext) {
     async () => {
       const editor = vscode.window.activeTextEditor;
       if (!editor) {
-        vscode.window.showErrorMessage("No active editor");
+        vscode.window.showErrorMessage(
+          "No active text editor to read cursor position"
+        );
         return;
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,6 +75,14 @@ export function activate(context: vscode.ExtensionContext) {
     return undefined;
   };
 
+  const formatPathForUri = (uri: vscode.Uri): string => {
+    if (!vscode.workspace.getWorkspaceFolder(uri)) {
+      return uri.fsPath;
+    }
+
+    return vscode.workspace.asRelativePath(uri);
+  };
+
   // Command: Copy relative path only (no line/column)
   // Triggered by: editor title button click, Cmd+Alt+C (macOS) / Ctrl+Alt+C (Win/Linux)
   const copyDisposable = vscode.commands.registerCommand(
@@ -87,7 +95,7 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       // Get the file path relative to the workspace root
-      const path = vscode.workspace.asRelativePath(uri);
+      const path = formatPathForUri(uri);
 
       // Copy to clipboard and show feedback
       await vscode.env.clipboard.writeText(path);
@@ -127,7 +135,7 @@ export function activate(context: vscode.ExtensionContext) {
 
       // Get the file path and append cursor position (1-indexed for user readability)
       const uri = editor.document.uri;
-      let path = vscode.workspace.asRelativePath(uri);
+      let path = formatPathForUri(uri);
       const position = editor.selection.active;
       path = `${path}:${position.line + 1}:${position.character + 1}`;
 


### PR DESCRIPTION
### Motivation
- Prevent the "No active editor" failure when copying paths for non-text or binary editor tabs by resolving the active resource from tabs as well as editors.
- Preserve the ability to copy `path:line:column` when a text editor is available while providing a clearer error when cursor data cannot be read.

### Description
- Add a `getActiveUri` helper that returns a `vscode.Uri` from `activeTextEditor` or the active tab input and supports `TabInputText`, `TabInputTextDiff`, `TabInputCustom`, `TabInputNotebook`, and fallback shapes with `uri`, `modified`, or `original` fields.
- Update the `copy-relative-path-button.copyRelativePath` command to use `getActiveUri` so copying the workspace-relative path works for non-text/binary tabs.
- Keep `copy-relative-path-button.copyRelativePathWithPosition` constrained to text editors and change its error message to `No active text editor to read cursor position` for clarity.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b514185a4832c97c4a149e0b826c9)